### PR TITLE
Allow % symbol in class names.

### DIFF
--- a/lib/lexer.js
+++ b/lib/lexer.js
@@ -271,7 +271,7 @@ Lexer.prototype = {
    */
 
   className: function() {
-    return this.scan(/^\.([\w-]+)/, 'class');
+    return this.scan(/^\.([\w-%]+)/, 'class');
   },
 
   /**


### PR DESCRIPTION
The skel css framework uses % symbol in class names.  Unless there is a good reason to prevent using the % symbol in class names in jade, I recommend this be merged.